### PR TITLE
Fix netbewust laden power not being displaced properly

### DIFF
--- a/example.rmd
+++ b/example.rmd
@@ -40,9 +40,12 @@ sessions_week <- get_sessions_week(sessions, "Charging Station")
 ```
 
 ```{r}
+source("model.R")
+
 results <- simulate(
   sessions,
   sessions_week,
+  n_runs=30,
   profile_type = "Charging Station",
   regular_profile = FALSE,
 )
@@ -56,6 +59,7 @@ results$individual %>%
 
 ```{r}
 results$individual %>%
-  filter(run_id==1) %>%
-  {plot_ly(x=.$date_time, y=.$power)}
+  filter(run_id==2) %>%
+  filter(date_time > "2022-10-01", date_time < "2022-12-01", power > 0) %>%
+  {plot_ly(x=.$date_time, y=.$power, color=.$n)}
 ```

--- a/model.R
+++ b/model.R
@@ -314,20 +314,17 @@ convert_samples <- function(samples, kW) {
       card_id,
       cs_id,
       start_datetime,
+      end_datetime,
       energy,
       week,
       n_intervals
     ) %>%
     dplyr::mutate(
       session_id = row_number(),
-      start_datetime = round_date(start_datetime, "15 mins"),
-      end_datetime = start_datetime + lubridate::minutes(n_intervals * 15),
-      end_datetime_min15 = end_datetime - lubridate::minutes(15)
-    ) %>%
-    filter(
-      !is.na(end_datetime_min15),
-      end_datetime > start_datetime
-    )
+      start_datetime = floor_date(start_datetime, "15 mins"),
+      end_datetime = ceiling_date(pmin(end_datetime, start_datetime + 3600*24), "15 mins"),
+    )  %>%
+    filter(end_datetime > start_datetime)
   
   return (samples)
 }
@@ -350,9 +347,10 @@ flatten_samples <- function(samples) {
     card_id,
     cs_id,
     # When flattening the sessions we need end_datetime_min15, otherwise we add 1 interval too much
-    date_time = seq(start_datetime, end_datetime_min15, by = "15 mins"),
+    date_time = seq(start_datetime, end_datetime, by = "15 mins"),
     week,
-    energy
+    energy,
+    n_intervals
   ), by = 1:nrow(samples)]
   
   samples <- samples %>%
@@ -368,7 +366,8 @@ flatten_samples <- function(samples) {
       week,
       wday,
       time,
-      energy
+      energy,
+      n_intervals
     )
   
   return (samples)
@@ -396,14 +395,18 @@ calculate_power <- function(samples, kW) {
     group_by(session_id) %>%
     dplyr::mutate(
       interval = row_number(),
-      interval = interval/n()
+      interval = pmin(interval / n_intervals, 1)
     )
   
   # Match sampled sessions with session power distribution based on normalized intervals
   idx <- match.closest(samples$interval, power_dist$x)
   samples$power <- power_dist[idx,]$kW
   
-  samples[samples$energy <= kW,]$power <- kW
+  samples <- samples %>%
+    group_by(session_id) %>%
+    mutate(power=ifelse(row_number() <= n_intervals, power, 0))
+  
+  # samples[samples$energy <= kW,]$power <- kW
   
   return (samples)
 }

--- a/model.R
+++ b/model.R
@@ -406,8 +406,6 @@ calculate_power <- function(samples, kW) {
     group_by(session_id) %>%
     mutate(power=ifelse(row_number() <= n_intervals, power, 0))
   
-  # samples[samples$energy <= kW,]$power <- kW
-  
   return (samples)
 }
 


### PR DESCRIPTION
Previously, power could not be pushed to later intervals as sessions ended too early. This is now fixed by making `n` dependent on the actual end time (max of 24h) of the sample.