### PR TITLE
Fix week merge

### DIFF
--- a/model.R
+++ b/model.R
@@ -355,7 +355,7 @@ flatten_samples <- function(samples) {
   
   samples <- samples %>%
     mutate(
-      wday = as.integer(lubridate::wday(date_time)),
+      wday = as.integer(lubridate::wday(date_time, week_start = 1)),
       time = format(date_time, format = "%H:%M")
     ) %>%
     # When the flattened session goes outside the week they are given they get chopped off.
@@ -365,7 +365,7 @@ flatten_samples <- function(samples) {
     arrange(session_id, date_time) %>%
     mutate(week=ifelse(wday < wday[1], week + 1, week)) %>%
     ungroup() %>%
-    
+    # 
     select(
       session_id,
       run_id,
@@ -512,7 +512,7 @@ create_profile <- function(samples, n_runs) {
   df_cp <- df_cp %>%
     mutate(
       week = isoweek(date_time),
-      wday = lubridate::wday(date_time, week_start = 1),
+      wday = lubridate::wday(date_time, week_start=1),
       time = format(date_time, format = "%H:%M"),
     )
   nrows_df_cp <- nrow(df_cp)
@@ -680,6 +680,7 @@ simulate <- function(
   capacity_fractions_path = NULL,
   season_dist_path = "data/Input/seasonality_distribution.rds"
 ) {
+  sessions <- sessions %>% mutate(actual_week=isoweek(start_datetime))
   # Read files
   season_dist <- readRDS(season_dist_path)
   

--- a/model.R
+++ b/model.R
@@ -597,7 +597,7 @@ distribute_overcapacity <- function(df_cps) {
       # We can only distribute the remainder if the vehicles are still connected
       overcapacity = power - capacity,
       remainder = pmax(power - capacity, 0),
-      not_charged_sum = ifelse(n == 0, remainder, 0),
+      remainder_after_leave = ifelse(n == 0, remainder, 0),
       remainder = ifelse(n > 0, remainder, 0)
     )
   
@@ -628,12 +628,12 @@ distribute_overcapacity <- function(df_cps) {
       group_by(run_id) %>%
       dplyr::mutate(
         remainder = pmax(power - capacity, 0),
-        not_charged_sum = ifelse(n == 0, not_charged_sum + remainder, not_charged_sum),
+        remainder_after_leave = ifelse(n == 0, remainder_after_leave + remainder, remainder_after_leave),
         remainder = ifelse(n > 0, remainder, 0)
       )
     
     df_cps %>%
-      mutate(not_charged_sum <- ifelse(date_time == date_time[n()], 0, not_charged_sum))
+      mutate(remainder_after_leave <- ifelse(date_time == date_time[n()], 0, remainder_after_leave))
     
   }
   
@@ -703,11 +703,10 @@ simulate <- function(
     capacity_fractions <- create_capacity_fractions_netbewust_laden(from, to, by, times=times)
     df_cps <- create_capacities_from_fractions(df_cps, max_capacity, base_capacity, capacity_fractions)
   }
-
-  print(df_cps)
   
   df_cps <- distribute_overcapacity(df_cps)
 
+  # Remove padding
   df_cps <- df_cps[df_cps$date_time >= "2022-01-01 00:00:00",]
   df_cps <- df_cps[df_cps$date_time <= "2022-12-31 23:59:59",]
   


### PR DESCRIPTION
Fix a problem where sessions at the end of the week were chopped off. The problem was that `lubridate::week` was used instead of `isoweek` which made it so that weeks of samples did not consistently go from Monday to Sunday. A correction was then added which made sure that samples starting on Sunday and ending on Monday had their week incremented on the Monday intervals.

Also added overcapacity and remainder-after-leave metrics.